### PR TITLE
Giscus 댓글 테마 변경 기능 수정

### DIFF
--- a/src/components/Comments/Giscus.tsx
+++ b/src/components/Comments/Giscus.tsx
@@ -1,17 +1,25 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { memo, useEffect } from "react";
+import { memo, useEffect, useRef } from "react";
 
 const Giscus = ({ className }: { className?: string }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const { theme: appTheme } = useTheme();
+  const giscusTheme =
+    appTheme === "dark" ? "noborder_gray" : "light_high_contrast";
 
   useEffect(() => {
-    const $container = document.getElementById("comments-giscus-container");
+    if (!containerRef.current || containerRef.current.hasChildNodes()) {
+      return;
+    }
 
     const $script = document.createElement("script");
-    $script.setAttribute("id", "comment-giscus");
-    $script.setAttribute("src", "https://giscus.app/client.js");
+    $script.src = "https://giscus.app/client.js";
+    $script.id = "comment-giscus";
+    $script.crossOrigin = "anonymous";
+    $script.async = true;
     $script.setAttribute("data-repo", "youngminss/wiki-docs");
     $script.setAttribute("data-repo-id", "R_kgDOL45lkQ");
     $script.setAttribute("data-category", "Comments");
@@ -22,20 +30,28 @@ const Giscus = ({ className }: { className?: string }) => {
     $script.setAttribute("data-emit-metadata", "0");
     $script.setAttribute("data-input-position", "bottom");
     $script.setAttribute("data-lang", "ko");
-    $script.setAttribute("crossorigin", "anonymous");
-
-    const giscusTheme =
-      appTheme === "dark" ? "noborder_gray" : "light_high_contrast";
     $script.setAttribute("data-theme", giscusTheme);
 
-    $container?.appendChild($script);
-  }, [appTheme]);
+    containerRef.current.appendChild($script);
+  }, [giscusTheme]);
+
+  useEffect(() => {
+    const iframe = document.querySelector<HTMLIFrameElement>(
+      "iframe.giscus-frame",
+    );
+
+    iframe?.contentWindow?.postMessage(
+      { giscus: { setConfig: { theme: giscusTheme } } },
+      "https://giscus.app",
+    );
+  }, [giscusTheme]);
 
   return (
     <div
+      ref={containerRef}
       id="comments-giscus-container"
       className={`mt-[3.2rem] border-t border-solid border-[var(--foreground)] pt-[3.2rem] ${className}`}
-    ></div>
+    />
   );
 };
 

--- a/src/components/buttons/ThemeModeButton.tsx
+++ b/src/components/buttons/ThemeModeButton.tsx
@@ -18,7 +18,7 @@ const ThemeModeButton = ({
   onClick?: () => void;
 }) => {
   const [mounted, setMounted] = useState(false);
-  const { setTheme, theme, systemTheme } = useTheme();
+  const { setTheme, theme } = useTheme();
 
   const ThemeModeItem = ({
     themeMode,
@@ -62,7 +62,7 @@ const ThemeModeButton = ({
         asChild
         className={`rounded-[0.4rem] bg-opacity-70 p-[0.8rem] hover:bg-[--foreground] dark:hover:text-[--background] ${className}`}
       >
-        {systemTheme === "dark" ? <Moon size={40} /> : <Sun size={40} />}
+        {theme === "dark" ? <Moon size={40} /> : <Sun size={40} />}
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top" align="end">
         <ThemeModeItem themeMode="light" label="Light" Icon={Sun} />

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -3,7 +3,12 @@ import { type ThemeProviderProps } from "next-themes/dist/types";
 
 const ThemeProvider = ({ children, ...props }: ThemeProviderProps) => {
   return (
-    <NextThemeProvider attribute="class" defaultTheme="dark" {...props}>
+    <NextThemeProvider
+      attribute="class"
+      defaultTheme="dark"
+      enableSystem
+      {...props}
+    >
       {children}
     </NextThemeProvider>
   );


### PR DESCRIPTION
## 작업 내용

- Giscus 테마 변경 기능 수정
  - as-is : useEffect 내 로직이 dependency 인 next-theme 가 변경될 때마다 재실행 -> 테마 변경 O, 리렌더링 O  
  - to-be : useEffect 내 로직이 초기 렌더링 이후에는 실행되지 않도록 (by. ref check), 테마 변경은 giscus 에서 제공하는 global method (= [postMessage](https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#parent-to-giscus-message-events)) 로 변경시킬 giscus-theme 를 넘겨 수정하도록함 -> 테마 변경 O, 리렌더링 X)

<br />

## 체크리스트

- [x] chrome
- [x] firefox
- [x] safari
