### PR TITLE
GA & GTM 스크립트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
+# env
+.env
 .env*.local
 
 # vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mdx-js/react": "^3.0.1",
         "@next/mdx": "^14.2.5",
+        "@next/third-parties": "^14.2.15",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toggle": "^1.0.3",
@@ -1086,6 +1087,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.2.15.tgz",
+      "integrity": "sha512-15CvipE1p1GtlzVfbDfXPrAGIhzJJe75Yy6+GIBRTd36lu95BegRsUJwCxJYoKz47Q09stcU2gJDMduMGqrikw==",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8012,6 +8025,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@mdx-js/react": "^3.0.1",
     "@next/mdx": "^14.2.5",
+    "@next/third-parties": "^14.2.15",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toggle": "^1.0.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import Footer from "@/components/layout/Footer";
 import Header from "@/components/layout/Header";
 import ThemeProvider from "@/components/providers/ThemeProvider";
 import Sonnar from "@/components/ui/Sonnar";
-import { GoogleAnalytics } from "@next/third-parties/google";
+import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
@@ -70,6 +70,7 @@ export default function RootLayout({
           />
         </ThemeProvider>
 
+        <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GA_ID} />
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Footer from "@/components/layout/Footer";
 import Header from "@/components/layout/Header";
 import ThemeProvider from "@/components/providers/ThemeProvider";
 import Sonnar from "@/components/ui/Sonnar";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
@@ -68,6 +69,8 @@ export default function RootLayout({
             }}
           />
         </ThemeProvider>
+
+        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
       </body>
     </html>
   );

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,9 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    NEXT_PUBLIC_GA_ID: string;
+  }
+}
+
+interface Window {
+  gtag: any;
+}


### PR DESCRIPTION
## 작업 내용

- [@next/third-parties](https://www.npmjs.com/package/@next/third-parties) 를 활용해 GA, GTM 컴포넌트 추가

> 현 상황에서는 기본적인 페이지 조회 정도만 필요해서 추가적인 커스텀 설정이 필요없다고 판단하여 페이지 로드 최적화에 신경을 써준 해당 라이브러리를 초안으로 사용하기로 함 

<br />

## 메모

- 페이지 조회 로직 추가 필요

## 체크리스트

- [x] chrome
- [x] firefox
- [x] safari
