### PR TITLE
코드블럭 복사 기능 추가

### DIFF
--- a/src/components/post/CustomCodeBlock.tsx
+++ b/src/components/post/CustomCodeBlock.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { DetailedHTMLProps, HTMLAttributes, useRef, useState } from "react";
+
+const CustomCodeBlock = ({
+  className = "",
+  children,
+  ...props
+}: DetailedHTMLProps<HTMLAttributes<HTMLPreElement>, HTMLPreElement>) => {
+  const [isCopied, setIsCopied] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const preRef = useRef<HTMLPreElement>(null);
+
+  const handleClickCopy = async () => {
+    const code = preRef.current?.textContent;
+
+    if (code) {
+      setIsLoading(true);
+      await navigator.clipboard.writeText(code);
+      setIsLoading(false);
+      setIsCopied(true);
+
+      setTimeout(() => {
+        setIsCopied(false);
+      }, 1500);
+    }
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <button
+        disabled={isCopied || isLoading}
+        aria-label={isCopied ? "Copied!" : "Copy code"}
+        onClick={handleClickCopy}
+        className="absolute right-[1rem] top-[1rem] z-[100] flex h-fit w-fit items-center gap-x-[0.4rem] rounded-[0.4rem] bg-black px-[0.8rem] py-[0.4rem] !text-[rgb(220,220,213)]"
+      >
+        <span className="relative h-[1.4rem] w-[1.4rem]">
+          {isCopied ? <Check size="100%" /> : <Copy size="100%" />}
+        </span>
+        <span className="text-[1.2rem]">{isCopied ? "Copied !" : "Copy"}</span>
+      </button>
+      <pre ref={preRef} {...props} className={className}>
+        {children}
+      </pre>
+    </div>
+  );
+};
+
+export default CustomCodeBlock;

--- a/src/components/post/PostBody.tsx
+++ b/src/components/post/PostBody.tsx
@@ -1,14 +1,14 @@
 import { rgbDataURL } from "@/functions/image";
 import { TPost } from "@/types/post";
-// import { transformerCopyButton } from "@rehype-pretty/transformers";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import Image from "next/image";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
-import rehypePrettyCode, { Options } from "rehype-pretty-code";
+import rehypePrettyCode, { type Options } from "rehype-pretty-code";
 import rehypeSlug from "rehype-slug";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import remarkUnwrapImages from "remark-unwrap-images";
+import CustomCodeBlock from "./CustomCodeBlock";
 
 const components = {
   h1: (props: any) => (
@@ -70,6 +70,7 @@ const components = {
     <li className="font-pretendard text-[1.6rem] leading-[150%]" {...props} />
   ),
   blockquote: (props: any) => <blockquote className="mb-[1.6rem]" {...props} />,
+  pre: (props: any) => <CustomCodeBlock {...props} />,
 };
 
 const prettyCodeOptions: Options = {
@@ -78,12 +79,6 @@ const prettyCodeOptions: Options = {
     dark: "slack-dark",
     light: "slack-dark",
   },
-  // transformers: [
-  //   transformerCopyButton({
-  //     visibility: "always",
-  //     feedbackDuration: 3000,
-  //   }),
-  // ],
 };
 
 const PostBody = ({ post }: { post: TPost }) => {


### PR DESCRIPTION
## 작업 내용

- 코드블럭 복사 기능 추가

<br />

## 메모

- 코드블록 구현을 위해 rehype-pretty-code plugin 을 사용 중이었고, experimental 기능이긴하나 [copy button 옵션이](https://rehype-pretty.pages.dev/plugins/copy-button/) 있어서 사용해보려 했으나, [rsc 에서 적용 시  error 이슈가](https://github.com/rehype-pretty/rehype-pretty-code/issues/235) 있으므로 기각
- 복사 버튼이 붙은 커스텀 pre component 를 pre element 대신 사용하도록 수정 (cc. https://github.com/rehype-pretty/rehype-pretty-code/issues/235#issuecomment-2351944796)
- 위 cc 를 참고해서 기능 구현은 되었으나, 스타일 측면으로 line 이 길어져서 스크롤이 되는 형태일 때 copy 버튼이 항상 우상단에 위치해야하는 요구사항을 만족시키지 못함, 최종적으로 pre element 와 copy button 을 감싸하는 div 컨테이너를 wrapping 함
  - copy button 은 div 기준으로 우상단을 계산하므로 항상 우상단에 위치하고
  - 스크롤이 될 수 있는 pre 코드블록은 코드블록대로 개별적으로 스크롤링 되도록 

<br />

## 체크리스트

- [x] chrome
- [x] firefox
- [x] safari
