### PR TITLE
json-ld schema 추가 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "rehype-unwrap-images": "^1.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.0",
+        "schema-dts": "^1.1.2",
         "sharp": "^0.33.4",
         "shiki": "^1.12.0",
         "sonner": "^1.5.0",
@@ -7476,6 +7477,15 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/schema-dts": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.2.tgz",
+      "integrity": "sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      }
+    },
     "node_modules/section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -8224,7 +8234,6 @@
       "version": "5.4.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "rehype-unwrap-images": "^1.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.0",
+    "schema-dts": "^1.1.2",
     "sharp": "^0.33.4",
     "shiki": "^1.12.0",
     "sonner": "^1.5.0",

--- a/src/app/blog/[category]/[slug]/page.tsx
+++ b/src/app/blog/[category]/[slug]/page.tsx
@@ -3,7 +3,9 @@ import PostFooter from "@/components/post/PostFooter";
 import PostHeader from "@/components/post/PostHeader";
 import PostToC from "@/components/post/PostToC";
 import { getPost } from "@/functions/post";
+import { generateBlogPostingSchema } from "@/functions/schema";
 import { Metadata, ResolvingMetadata } from "next";
+import Script from "next/script";
 
 type TPostDetailProps = {
   params: { category: string; slug: string };
@@ -16,7 +18,7 @@ export async function generateMetadata(
   const post = await getPost({ category, slug });
   const { title, introduction, thumbnail, keywords, createdAt } = post;
 
-  const metadata = {
+  const metadata: Metadata = {
     title,
     description: introduction,
     keywords,
@@ -29,8 +31,8 @@ export async function generateMetadata(
       images: thumbnail
         ? {
             url: thumbnail,
-            width: 1200,
-            height: 800,
+            width: "1200",
+            height: "800",
           }
         : undefined,
       locale: "ko_KR",
@@ -47,6 +49,8 @@ const PostDetail = async ({ params: { category, slug } }: TPostDetailProps) => {
     slug: slug,
   });
 
+  const blogPostingSchema = generateBlogPostingSchema({ category, slug, post });
+
   return (
     <main>
       <div className="mx-auto flex max-w-[64rem] flex-col px-[1.6rem]">
@@ -56,6 +60,11 @@ const PostDetail = async ({ params: { category, slug } }: TPostDetailProps) => {
       </div>
 
       <PostToC />
+
+      <Script
+        type="application/ld-json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(blogPostingSchema) }}
+      />
     </main>
   );
 };

--- a/src/app/blog/[category]/[slug]/page.tsx
+++ b/src/app/blog/[category]/[slug]/page.tsx
@@ -62,6 +62,7 @@ const PostDetail = async ({ params: { category, slug } }: TPostDetailProps) => {
       <PostToC />
 
       <Script
+        id="post-schema"
         type="application/ld-json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(blogPostingSchema) }}
       />

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,16 +2,21 @@ import PostCard from "@/components/post/PostCard";
 import Avatars from "@/components/ui/Avatars";
 import { parseDate } from "@/functions/date";
 import { getPostList } from "@/functions/post";
+import { generateBlogSchema } from "@/functions/schema";
 import { AUTHOR_NAME, GITHUB_PROFILE, PROFILE_BIO } from "@/utils/const";
-import { ResolvingMetadata } from "next";
+import { Metadata, ResolvingMetadata } from "next";
+import Script from "next/script";
 
 export async function generateMetadata(_: any, parent: ResolvingMetadata) {
   const parentOpenGraph = (await parent).openGraph;
 
-  const metadata = {
-    ...parentOpenGraph,
+  const metadata: Metadata = {
     title: `Blog`,
-    url: `${parentOpenGraph?.url}/blog`,
+    openGraph: {
+      ...parentOpenGraph,
+      title: `Blog`,
+      url: `${parentOpenGraph?.url}/blog`,
+    },
   };
 
   return metadata;
@@ -23,6 +28,8 @@ const Posts = async () => {
       ? 1
       : -1,
   );
+
+  const blogSchema = generateBlogSchema();
 
   return (
     <main className="mx-auto min-h-[calc(100vh_-_18.9rem)] max-w-[64rem]">
@@ -46,6 +53,11 @@ const Posts = async () => {
           return <PostCard key={`${category}_${slug}_postCard`} post={post} />;
         })}
       </div>
+
+      <Script
+        type="application/ld-json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(blogSchema) }}
+      />
     </main>
   );
 };

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -55,6 +55,7 @@ const Posts = async () => {
       </div>
 
       <Script
+        id="blog-schema"
         type="application/ld-json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(blogSchema) }}
       />

--- a/src/functions/schema.ts
+++ b/src/functions/schema.ts
@@ -1,0 +1,68 @@
+import { TPost } from "@/types/post";
+import { AUTHOR_NAME, GITHUB_PROFILE } from "@/utils/const";
+import { Blog, BlogPosting } from "schema-dts";
+
+export const generateBlogSchema = (): Blog => {
+  return {
+    "@type": "Blog",
+    name: "Youngminss-log",
+    url: "https://www.youngminss-log.com",
+    about: "Web Development, Tech, Programming",
+    description: "Youngminss-log 입니다. 주로 웹 개발 관련 글을 기록합니다.",
+    dateCreated: "2024.10.28",
+    author: {
+      "@type": "Person",
+      name: AUTHOR_NAME,
+      image: {
+        "@type": "ImageObject",
+        url: GITHUB_PROFILE,
+        width: "100",
+        height: "100",
+      },
+    },
+    inLanguage: "ko",
+  };
+};
+
+export const generateBlogPostingSchema = ({
+  category,
+  slug,
+  post,
+}: {
+  category: string;
+  slug: string;
+  post: TPost;
+}): BlogPosting => {
+  const { title, thumbnail, introduction, content, keywords, createdAt } = post;
+
+  return {
+    "@type": "BlogPosting",
+    headline: title,
+    articleBody: content,
+    description: introduction,
+    keywords: keywords,
+    datePublished: createdAt.split(" ").at(0),
+    wordCount: content.length,
+    author: {
+      "@type": "Person",
+      name: AUTHOR_NAME,
+      image: {
+        "@type": "ImageObject",
+        url: GITHUB_PROFILE,
+        width: "100",
+        height: "100",
+      },
+    },
+    image: {
+      "@type": "ImageObject",
+      url: thumbnail,
+      width: "1200",
+      height: "800",
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": `https://www.youngminss-log.com/${category}/${slug}`,
+      url: `https://www.youngminss-log.com/blog/${category}/${slug}`,
+    },
+  };
+};


### PR DESCRIPTION
## 작업 내용

- json-ld schema 추가 

<br />

## 메모

- Post 리스트 페이지 & 상세 페이지에 대한 json-ld schema 추가
- Next.js 의 `<Script />` 태그에 다음과 같이 추가, page.tsx or layout.tsx 의 렌더링 하단에 배치
```tsx
<Script
  id="post-schema"
  type="application/ld-json"
  dangerouslySetInnerHTML={{ __html: JSON.stringify(blogPostingSchema) }}
/>
```

<br />

## 체크리스트

- [x] chrome
- [x] firefox
- [x] safari
