### PR TITLE
[hotfix] 포스팅 카드 업로드 시간 업데이트 안되는 현상 & 루트 썸네일 이미지 변경

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
     siteName: "youngminss-log",
     url: "www.youngminss-log.com",
     images: {
-      url: "https://img.notionusercontent.com/s3/prod-files-secure%2F1e48ae17-fbee-406f-9bca-eaae95ca4225%2F423c0680-e08e-481d-8b03-49485cbbe0ea%2Fdefault-thumbnail.webp/size/w=1420?exp=1728609878&sig=worghfA3ILv-f4kAAL6KkPKMcVGa8Wk3GmOM6GAXYn8",
+      url: "https://img.notionusercontent.com/s3/prod-files-secure%2F1e48ae17-fbee-406f-9bca-eaae95ca4225%2Fcd3aabb2-241e-4409-bef9-3cbf3bc1f5a3%2Fthumbnail-default.webp/size/w=2000?exp=1730394410&sig=7HLE-bBjWrZSeJzSfzbZW-Oe7ZNOf0iCcqVNu1MX0G4",
       width: 1200,
       height: 800,
     },

--- a/src/components/post/PostCard.tsx
+++ b/src/components/post/PostCard.tsx
@@ -1,8 +1,8 @@
-import { timeDifference } from "@/functions/date";
 import { rgbDataURL } from "@/functions/image";
 import { TPost } from "@/types/post";
 import Image from "next/image";
 import Link from "next/link";
+import TimeDifference from "./common/TimeDifference";
 
 const PostCard = async ({ post }: { post: TPost }) => {
   const { url, title = "", introduction, thumbnail, createdAt } = post;
@@ -19,7 +19,7 @@ const PostCard = async ({ post }: { post: TPost }) => {
             )}
           </div>
 
-          <span className="pt-[1.2rem]">{timeDifference(createdAt)}</span>
+          <TimeDifference createdAt={createdAt} />
         </div>
 
         {thumbnail && (

--- a/src/components/post/common/TimeDifference.tsx
+++ b/src/components/post/common/TimeDifference.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { timeDifference } from "@/functions/date";
+
+const TimeDifference = ({
+  className = "",
+  createdAt,
+}: {
+  className?: string;
+  createdAt: string;
+}) => {
+  return (
+    <span className={`pt-[1.2rem] ${className}`}>
+      {timeDifference(createdAt)}
+    </span>
+  );
+};
+
+export default TimeDifference;


### PR DESCRIPTION
## 작업 내용

- 포스팅 카드 업로드 시간 영역만 client 컴포넌트로 분리
- 루트 썸네일 이미지의 텍스트 오타로 인해 변경

<br />

## 체크리스트

- [x] chrome
- [x] firefox
- [x] safari
