### PR TITLE
Static-Site-Generation(SSG) (포스트 리스트, 포스트 상세 페이지)

### DIFF
--- a/src/app/blog/[category]/[slug]/page.tsx
+++ b/src/app/blog/[category]/[slug]/page.tsx
@@ -2,7 +2,7 @@ import PostBody from "@/components/post/PostBody";
 import PostFooter from "@/components/post/PostFooter";
 import PostHeader from "@/components/post/PostHeader";
 import PostToC from "@/components/post/PostToC";
-import { getPost } from "@/functions/post";
+import { getPost, getPostList } from "@/functions/post";
 import { generateBlogPostingSchema } from "@/functions/schema";
 import { Metadata, ResolvingMetadata } from "next";
 import Script from "next/script";
@@ -11,12 +11,24 @@ type TPostDetailProps = {
   params: { category: string; slug: string };
 };
 
+export const dynamic = "force-static";
+export const revalidate = false; // revalidate: false = Infinity, default 긴 한데 명시적으로 선언
+
+export async function generateStaticParams() {
+  const postList = await getPostList();
+
+  return postList.map((post) => ({
+    category: post.category,
+    slug: post.slug,
+  }));
+}
+
 export async function generateMetadata(
   { params: { category, slug } }: TPostDetailProps,
   parent: ResolvingMetadata,
 ): Promise<Metadata> {
   const post = await getPost({ category, slug });
-  const { title, introduction, thumbnail, keywords, createdAt } = post;
+  const { title, introduction, thumbnail, keywords } = post;
 
   const metadata: Metadata = {
     title,

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -7,6 +7,9 @@ import { AUTHOR_NAME, GITHUB_PROFILE, PROFILE_BIO } from "@/utils/const";
 import { Metadata, ResolvingMetadata } from "next";
 import Script from "next/script";
 
+export const dynamic = "force-static";
+export const revalidate = false;
+
 export async function generateMetadata(_: any, parent: ResolvingMetadata) {
   const parentOpenGraph = (await parent).openGraph;
 

--- a/src/components/post/PostHeader.tsx
+++ b/src/components/post/PostHeader.tsx
@@ -66,6 +66,7 @@ const PostHeader = ({ post }: { post: TPost }) => {
             objectFit="cover"
             placeholder="blur"
             blurDataURL={rgbDataURL(233, 233, 233)}
+            priority
           />
         </div>
       )}


### PR DESCRIPTION
## 작업 내용

- Static-Site-Generation(SSG) (포스트 리스트, 포스트 상세 페이지)

<br />

## 메모

as-is
- 모든 페이지가 SSR 처리

to-be
- 현재 기준) 특성 상 빌드 시점 이후로 업데이트 액션이 있는 컨텐츠는 없기 떄문에 SSG 하도록 수정
  - Route Segment Config 에서 [dynamic](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic), [revalidate](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate) 을 조정
    ```tsx
    export const dynamic = "force-static";
    export const revalidate = false; // revalidate: false = Infinity, default 긴 한데 명시적으로 선언
    ``` 
- 글 상세 페이지의 경우 [generateStaticParams](https://nextjs.org/docs/app/api-reference/functions/generate-static-params) (= page router 의 경우 [getStaticPaths](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-paths)) 에서 접근 가능한 경로에 대한 { category, slug } 리스트를 반환해서 빌드 타임 접근 가능한 글 상세 페이지들에 대한 SSG 진행
  ```tsx
  export async function generateStaticParams() {
  const postList = await getPostList();

  return postList.map((post) => ({
    category: post.category,
    slug: post.slug,
  }));
  }
  ``` 

## 미비사항

### not-found 처리

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/e1b7fa1f-cffa-44f5-b9eb-2b1b50d12a28">

 - SSG 로 빌드 타임에 생성된 경로에 대해서는 정적인 컨텐츠가 존재하지만, 존재하지 않는 경로로 사용자가 접근하게되면 위와 같이 next 에서는 존재하지 않는 경로라 판단하여 500 error 를 발생시킴
 - 컨텐츠가 존재하지 않는 경로로 접근 시에 home 이나 이전 페이지로 이동 시키는 404 페이지 역할인 [not-found](https://nextjs.org/docs/app/api-reference/file-conventions/not-found) 처리 필요

<br />

## 체크리스트

- [x] chrome
- [x] firefox
- [x] safari
