### PR TITLE
Table 내 컨텐츠 스타일 버그 수정 및 PostCard 스타일 수정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -246,3 +246,9 @@ blockquote > p {
 :not(pre) > p > code {
   @apply mx-[0.2rem] rounded border px-[0.4rem] py-[0.1rem] font-pretendard text-[1.6rem] font-semibold;
 }
+
+/* (in. safari) table 내 media 같이 사이즈가 큰 컨텐츠가 들어가는 경우, 다음 컨텐츠와 겹침 현상 발생 대응을 위해 */
+/* https://stackoverflow.com/questions/51524842/what-are-webkit-paged-y-and-webkit-paged-x-values-for-overflow */
+.overflow-paged-x {
+  overflow: -webkit-paged-x;
+}

--- a/src/components/post/PostBody.tsx
+++ b/src/components/post/PostBody.tsx
@@ -110,7 +110,10 @@ const components = {
     />
   ),
   td: (props: any) => (
-    <td className="font-pretendard text-[1.4rem] [&>*]:m-0" {...props} />
+    <td
+      className="overflow-paged-x font-pretendard text-[1.4rem] [&>*]:m-0"
+      {...props}
+    />
   ),
 };
 

--- a/src/components/post/PostCard.tsx
+++ b/src/components/post/PostCard.tsx
@@ -9,7 +9,7 @@ const PostCard = async ({ post }: { post: TPost }) => {
 
   return (
     <Link href={url} className="group">
-      <div className="relative flex justify-between gap-x-[1.6rem] overflow-clip transition-all duration-200 max-postCard:mx-[1.6rem] max-postCard:flex-col-reverse max-postCard:gap-y-[1.6rem] max-postCard:rounded-[0.4rem] max-postCard:shadow-lg max-postCard:shadow-[var(--foreground)] max-postCard:group-active:scale-95 postCard:px-[1.6rem] postCard:py-[2.4rem] postCard:will-change-transform postCard:group-hover:translate-x-[0.8rem] postCard:group-hover:bg-[var(--foreground)] postCard:group-hover:text-[var(--background)]">
+      <div className="relative flex justify-between gap-x-[1.6rem] overflow-clip transition-all duration-200 max-postCard:mx-[1.6rem] max-postCard:flex-col-reverse max-postCard:gap-y-[1.6rem] max-postCard:rounded-[0.4rem] max-postCard:border max-postCard:border-solid max-postCard:border-[var(--foreground)] max-postCard:shadow-lg max-postCard:group-active:scale-95 postCard:px-[1.6rem] postCard:py-[2.4rem] postCard:will-change-transform postCard:group-hover:translate-x-[0.8rem] postCard:group-hover:bg-[var(--foreground)] postCard:group-hover:text-[var(--background)]">
         <div className="flex flex-1 flex-col justify-between max-postCard:px-[1.6rem] max-postCard:pb-[1.6rem]">
           <div className="flex flex-col gap-y-[1.2rem]">
             <h2 className="text-[2.2rem] font-bold">{title}</h2>


### PR DESCRIPTION
## 작업 내용

- (in. safari) table 내 media 같이 컨텐츠 크기가 큰 경우 다음 컨텐츠가 테이블에 덮힘 현상 핸들링 
- PostCard shadow color 제거

<br />

## 메모

**(in. safari) table 내 media 같이 컨텐츠 크기가 큰 경우 다음 컨텐츠가 테이블에 덮힘 현상 핸들링**

- https://stackoverflow.com/questions/51524842/what-are-webkit-paged-y-and-webkit-paged-x-values-for-overflow

```
Chromium (Chrome 75, June 2019) removed support for
overflow: -webkit-paged-x and -webkit-paged-y. Currently it is still supported by WebKit/Safari.
```

## 체크리스트

- [x] chrome
- [x] firefox
- [x] safari
