### PR TITLE
Sitemap.xml 초안 생성

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,36 @@
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://www.youngminss-log.com",
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
+      url: "https://www.youngminss-log.com/blog",
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: "https://www.youngminss-log.com/blog/nextjs-blog/building-project-with-mdx",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: "https://www.youngminss-log.com/blog/nextjs-blog/customizing-code-block",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: "https://www.youngminss-log.com/blog/nextjs-blog/implementing-code-block-copy",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+  ];
+}


### PR DESCRIPTION
## 작업 내용

- Sitemap.xml 초안 생성

<br />

## 메모

![image](https://github.com/user-attachments/assets/ddaabe75-4bb5-4e45-9098-137d3dc66f18)

- 블로그 초반이라 컨텐츠가 많지 않기 때문에 app route 에서 정적으로 접근 가능한 경로를 추가했음 (cc. https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap#generating-a-sitemap-using-code-js-ts)
- 상황에 따라 dynamic 하게 sitemap 을 generate 하는 방법도 next 에서 제공함 (cc. https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap#generating-multiple-sitemaps)

<br />

## 체크리스트

- [x] chrome
- [x] firefox
- [x] safari
